### PR TITLE
Adding apt https transports

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install apt HTTPS Transport | apt
+  apt:
+    state: latest
+    pkg: apt-transport-https
+
 - name: "Import Signing Key via HKP | {{ repository_key }}"
   apt_key:
     state: present


### PR DESCRIPTION
The node.js package uses `https` to install the versions of node and it's failing out right now.

Details of apt package: https://packages.debian.org/sid/apt-transport-https
Details of ansible-nodejs usage: https://github.com/telusdigital/ansible-nodejs/blob/master/meta/main.yml#L5